### PR TITLE
Add minimal repair ticket tracking server

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,24 @@
+# IT and Cloud Service Tracker
 
+This is a minimal Node.js application that allows technicians to create and track service tickets for client equipment.
+
+## Usage
+
+```
+npm start
+```
+Starts the HTTP server on port 3000.
+
+```
+npm test
+```
+Runs the test suite.
+
+## API
+
+- `POST /tickets` – Create a ticket. Body should include `clientName`, `equipment`, and `description`.
+- `GET /tickets` – List all tickets.
+- `GET /tickets/:id` – Get a specific ticket.
+- `PUT /tickets/:id/status` – Update the status of a ticket by providing `{ "status": "..." }`.
+
+Tickets are kept in memory for simplicity and are not persisted.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "itandcloudapp",
+  "version": "1.0.0",
+  "description": "Simple service ticket tracker",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,75 @@
+const http = require('http');
+
+let tickets = [];
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  if (req.method === 'POST' && url.pathname === '/tickets') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { clientName, equipment, description } = JSON.parse(body || '{}');
+        const ticket = {
+          id: String(Date.now()),
+          clientName,
+          equipment,
+          description,
+          status: 'received'
+        };
+        tickets.push(ticket);
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(ticket));
+      } catch (err) {
+        res.writeHead(400);
+        res.end();
+      }
+    });
+  } else if (req.method === 'GET' && url.pathname === '/tickets') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(tickets));
+  } else if (req.method === 'GET' && url.pathname.startsWith('/tickets/')) {
+    const id = url.pathname.split('/')[2];
+    const ticket = tickets.find(t => t.id === id);
+    if (ticket) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(ticket));
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  } else if (req.method === 'PUT' && url.pathname.startsWith('/tickets/') && url.pathname.endsWith('/status')) {
+    const id = url.pathname.split('/')[2];
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { status } = JSON.parse(body || '{}');
+        const ticket = tickets.find(t => t.id === id);
+        if (ticket) {
+          ticket.status = status;
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(ticket));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      } catch (err) {
+        res.writeHead(400);
+        res.end();
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+module.exports = { server, tickets };
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  server.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { server } = require('../src/server');
+
+const PORT = 3001;
+
+const fetchJSON = async (url, options = {}) => {
+  const res = await fetch(url, {
+    ...options,
+    headers: { 'Content-Type': 'application/json', ...(options.headers || {}) }
+  });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); } catch { json = text; }
+  return { status: res.status, body: json };
+};
+
+test('ticket lifecycle', async (t) => {
+  await new Promise(resolve => server.listen(PORT, resolve));
+  t.after(() => server.close());
+
+  const base = `http://localhost:${PORT}`;
+
+  // create ticket
+  let res = await fetchJSON(`${base}/tickets`, {
+    method: 'POST',
+    body: JSON.stringify({ clientName: 'Jean', equipment: 'Laptop', description: 'Ne démarre pas' })
+  });
+  assert.strictEqual(res.status, 201);
+  assert.strictEqual(res.body.status, 'received');
+  const id = res.body.id;
+
+  // get ticket
+  res = await fetchJSON(`${base}/tickets/${id}`);
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.clientName, 'Jean');
+
+  // update status
+  res = await fetchJSON(`${base}/tickets/${id}/status`, {
+    method: 'PUT',
+    body: JSON.stringify({ status: 'delivered' })
+  });
+  assert.strictEqual(res.status, 200);
+  assert.strictEqual(res.body.status, 'delivered');
+
+  // list tickets
+  res = await fetchJSON(`${base}/tickets`);
+  assert.strictEqual(res.status, 200);
+  assert.ok(Array.isArray(res.body));
+  assert.strictEqual(res.body.length, 1);
+});


### PR DESCRIPTION
## Summary
- implement Node.js HTTP server to create and manage repair tickets
- add tests for ticket creation, retrieval, update and listing
- document usage and API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add8e4eea08332a6dff0ebf2c291ac